### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Magnitude and Phase images in NIfTI fileformat (4D images with echoes in the 4th
 Open the REPL in Julia and type
 
 ```julia
-import Pkg;
+using Pkg
 Pkg.add(PackageSpec(url="https://github.com/korbinian90/MRI.jl"))
 Pkg.add(PackageSpec(url="https://github.com/korbinian90/SWI.jl"))
 ```
@@ -35,15 +35,15 @@ nifti_folder = SWI.dir("test","testData","small")
 magfile = joinpath(nifti_folder, "Mag.nii")
 phasefile = joinpath(nifti_folder, "Phase.nii")
 
-mag = readmag(magfile)
-phase = readphase(phasefile)
+mag = SWI.readmag(magfile)
+phase = SWI.readphase(phasefile)
 data = Data(mag, phase, mag.header, TEs)
 
-swi = calculateSWI(data)
-mip = createMIP(swi)
+swi = SWI.calculateSWI(data)
+mip = SWI.createMIP(swi)
 
-savenii(swi, "<outputpath>/swi.nii"; header=mag.header)
-savenii(mip, "<outputpath>/mip.nii"; header=mag.header)
+SWI.savenii(swi, "<outputpath>/swi.nii"; header=mag.header)
+SWI.savenii(mip, "<outputpath>/mip.nii"; header=mag.header)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Build Status](https://api.cirrus-ci.com/github/korbinian90/SWI.jl.svg)](https://cirrus-ci.com/github/korbinian90/SWI.jl)
 
 # Susceptibility Weighted Imaging (SWI)
-SWI provides magnetic resonance images with improved vein and iron contrast by weighting the magnitude image with a preprocessed phase image. This package has the additional capability of multi-echo SWI, intensity correction and improved phase processing.
+SWI provides magnetic resonance images with improved vein and iron contrast by weighting the magnitude image with a preprocessed phase image. This package has the additional capability of multi-echo SWI, intensity correction and improved phase processing. It can also work with classical single-echo SWI.
 
 ## Getting Started
 
@@ -30,10 +30,10 @@ This is a simple multi-echo case without changing default behavior
 ```julia
 using SWI
 
-TEs = [4,8,12]
+TEs = [4,8,12] # change this to the Echo Time of your SWI sequence. For multi-echoes, set a list of TE values, else set a list with a single TE value.
 nifti_folder = SWI.dir("test","testData","small")
-magfile = joinpath(nifti_folder, "Mag.nii")
-phasefile = joinpath(nifti_folder, "Phase.nii")
+magfile = joinpath(nifti_folder, "Mag.nii") # Path to the magnitude image in nifti format, must be .nii or .hdr
+phasefile = joinpath(nifti_folder, "Phase.nii") # Path to the phase image
 
 mag = SWI.readmag(magfile)
 phase = SWI.readphase(phasefile)
@@ -42,7 +42,7 @@ data = Data(mag, phase, mag.header, TEs)
 swi = SWI.calculateSWI(data)
 mip = SWI.createMIP(swi)
 
-SWI.savenii(swi, "<outputpath>/swi.nii"; header=mag.header)
+SWI.savenii(swi, "<outputpath>/swi.nii"; header=mag.header) # change <outputpath> with the path where you want to save the reconstructed SWI images
 SWI.savenii(mip, "<outputpath>/mip.nii"; header=mag.header)
 ```
 


### PR DESCRIPTION
Update the README.md with proper instructions to install the package on Julia > 1.3, and add a few comments to guide the user on how to use the package.

BTW, awesome work on this package! That's currently the only complete SWI software reconstruction package, others (such as [swi on MATLAB](https://web.archive.org/web/20110816131622/http://fmri.ucsd.edu/Howto/swi.shtml) and [Spin-Lite](http://www.mrimaging.com/category.88.html)) are now dead links and do not work on nifti but on old defunct image formats. Thanks a lot for making this awesome library under opensource!